### PR TITLE
feat: Change default line-length to 79 characters in `black`, `flake`, and `isort` configuration files for PEP8 compatibility.

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -7,7 +7,7 @@ exclude =
     build,
     dist,
     doc/source/conf.py
-max-line-length = 115
+max-line-length = 79
 # Ignore some style 'errors' produced while formatting by 'black'
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#labels-why-pycodestyle-warnings
 extend-ignore = E203

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 # Keep import statement below line_length character limit
-line_length = 115
+line_length = 79
 multi_line_output = 3
 include_trailing_comma = True

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: sckit-package
+name: scikit-package
 channels:
   - conda-forge
 dependencies:

--- a/news/line-length.rst
+++ b/news/line-length.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Change default line-length to 79 characters in `black`, `flake`, and `isort` configuration files for PEP8 compatibility.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
 [tool.black]
-line-length = 115
+line-length = 79
 include = '\.pyi?$'
 exclude = '''
 /(

--- a/{{ cookiecutter.github_repo_name }}/.flake8
+++ b/{{ cookiecutter.github_repo_name }}/.flake8
@@ -7,7 +7,7 @@ exclude =
     build,
     dist,
     doc/source/conf.py
-max-line-length = 115
+max-line-length = 79
 # Ignore some style 'errors' produced while formatting by 'black'
 # https://black.readthedocs.io/en/stable/guides/using_black_with_other_tools.html#labels-why-pycodestyle-warnings
 extend-ignore = E203

--- a/{{ cookiecutter.github_repo_name }}/.isort.cfg
+++ b/{{ cookiecutter.github_repo_name }}/.isort.cfg
@@ -1,5 +1,5 @@
 [settings]
 # Keep import statement below line_length character limit
-line_length = 115
+line_length = 79
 multi_line_output = 3
 include_trailing_comma = True

--- a/{{ cookiecutter.github_repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.github_repo_name }}/pyproject.toml
@@ -64,7 +64,7 @@ ignore-words = ".codespell/ignore_words.txt"
 skip = "*.cif,*.dat"
 
 [tool.black]
-line-length = 115
+line-length = 79
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
Closes #239 
Replaces #242 