### PR TITLE
chore: remove an extra blank in e.g., `src/diffpy/__init__.py`

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -32,7 +32,6 @@ from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
 # End of file
-
 """
     return __init__
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -24,7 +24,6 @@ def __gen_init__(module_name):
 # See LICENSE.rst for license information.
 #
 ##############################################################################
-
 \"\"\"Blank namespace package for module {module_name}.\"\"\"
 
 

--- a/news/remove-empty.rst
+++ b/news/remove-empty.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news added: remove an empty line when a new project is created.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Here, just remove one empty blank line that is later processed by pre-commit automatically as shown below:

<img width="1100" alt="Screenshot 2025-02-06 at 12 34 23 PM" src="https://github.com/user-attachments/assets/c645e00a-2edc-4b75-b475-e0249b8e7809" />
