### PR TITLE
CI: Add `github_admin_username` to PyPI GitHub CI release

### DIFF
--- a/.github/workflows/build-wheel-release-upload.yml
+++ b/.github/workflows/build-wheel-release-upload.yml
@@ -11,6 +11,8 @@ jobs:
     uses: Billingegroup/release-scripts/.github/workflows/_build-wheel-release-upload.yml@v0
     with:
       project: scikit-package
+      github_admin_username: sbillinge
+
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
`github_admin_username: sbillinge` has been added. 

@sbillinge ready for review - hopefully this will make our PyPI release successful. 