### PR TITLE
docs: fix typo in how to start guide

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -49,4 +49,3 @@ Release Notes
 **Fixed:**
 
 * Update corresponding email to sb2896@columbia.edu.
-

--- a/doc/source/new-project-guide.rst
+++ b/doc/source/new-project-guide.rst
@@ -10,10 +10,8 @@ How to start a new Python project with scikit-package
 
 .. include:: snippets/scikit-installation.rst
 
-Overview
-
 scikit-package main workflow
------------------------------
+----------------------------
 
 1. Type ``package create`` inside the project directory.
 
@@ -21,21 +19,8 @@ scikit-package main workflow
 
 .. include:: snippets/package-create-user-inputs.rst
 
-.. _new-project-guide-build-package:
-
-3. Ensure you can build your project
-4.
-Check your documentation
-------------------------
-
-# Build your documentation locally:
-
-.. include:: snippets/doc-build-instruction.rst
-
-Host your project on GitHub
----------------------------
-
-Here, we will not use a PR workflow. Instead, the goal here is to host your project on GitHub.
+Host your new project on GitHub
+-------------------------------
 
 #. Make sure you have a GitHub account.
 
@@ -57,7 +42,3 @@ Here, we will not use a PR workflow. Instead, the goal here is to host your proj
     git commit -m "skpkg: start a new project with scikit-package"
     git branch -M main
     git push --set-upstream origin main
-
-Hello world
-
-:ref:`Helo <migration-guide-move-files>`

--- a/news/feb25-doc.rst
+++ b/news/feb25-doc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* no news added: fix typos after 0.0.2 in documenation.
+* no news added: fix typos after 0.0.2 in documentation.
 
 **Changed:**
 

--- a/news/feb25-doc.rst
+++ b/news/feb25-doc.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news added: fix typos after 0.0.2 in documenation.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Some of immediate fixes in the docs. Will merge it since we will do an overall review later. 