### PR TITLE
style: remove `prof.` from readme

### DIFF
--- a/{{ cookiecutter.github_repo_name }}/README.rst
+++ b/{{ cookiecutter.github_repo_name }}/README.rst
@@ -121,4 +121,4 @@ Before contributing, please read our `Code of Conduct <https://github.com/{{ coo
 Contact
 -------
 
-For more information on {{ cookiecutter.conda_pypi_package_dist_name }} please visit the project `web-page <https://{{ cookiecutter.github_org }}.github.io/>`_ or email Prof. {{ cookiecutter.project_owner_name }} at {{ cookiecutter.project_owner_email }}.
+For more information on {{ cookiecutter.conda_pypi_package_dist_name }} please visit the project `web-page <https://{{ cookiecutter.github_org }}.github.io/>`_ or email {{ cookiecutter.project_owner_name }} at {{ cookiecutter.project_owner_email }}.


### PR DESCRIPTION
Having this makes everyone that creates their own package a professor. 