### PR TITLE
fix: lowercase package directory name under src directory for namespace package

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -90,7 +90,7 @@ def add_supermodules(ROOT, name):
     # Get the necessary modules given the period spacings
     module_names = name.split(".")
     for i, module in enumerate(module_names):
-        module_names[i] = module.strip()
+        module_names[i] = module.strip().lower()
 
     # The last module is not a namespace module
     ns_module_names = module_names[:-1]

--- a/news/lowercap.rst
+++ b/news/lowercap.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Lowercase package directory name under src directory for namespace package.
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes https://github.com/Billingegroup/scikit-package/issues/283

When the user enters `diffpy.SAF`, the directory name under `src` becomes `saf` instead of `SAF`

