### PR TITLE
docs: implement docstrings to `dot_product` fuction using group's standards.

### DIFF
--- a/news/better-tests.rst
+++ b/news/better-tests.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add docstrings to the dot_product function used for the demo code within src/calcualtor.py.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/better-tests.rst
+++ b/news/better-tests.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Add docstrings to the dot_product function used for the demo code within src/calcualtor.py.
+* Add docstrings to the dot_product function used for the demo code within src/calculator.py.
 
 **Changed:**
 

--- a/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
@@ -22,7 +22,6 @@ def dot_product(a, b):
 
     Examples
     --------
-
     Compute the dot product of two lists:
     >>> a = [1, 2, 3]
     >>> b = [4, 5, 6]

--- a/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
@@ -28,7 +28,7 @@ def dot_product(a, b):
     >>> dot_product(a, b)
     32.0
 
-    Compute the dot product of two tuples
+    Compute the dot product of two tuples:
     >>> a = (1, 2, 3)
     >>> b = (4, 5, 6)
     >>> dot_product(a, b)

--- a/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
@@ -4,13 +4,14 @@ import numpy as np
 def dot_product(a, b):
     """Compute the dot product of two vectors of any size.
 
-    Ensure that the inputs of a and b are of the same size.
-    The supported types are Python list, Python tuple, and NumyPy array.
+    Ensure that the inputs, a and b, are of the same size.
+    The supported types are "array_like" objects, which can
+    be converted to a NumPy array. Examples include lists and tuples.
 
     Parameters
     ----------
     a : array_like
-        The first input of vector.
+        The first input vector.
     b : array_like
         The second input vector.
 
@@ -25,18 +26,6 @@ def dot_product(a, b):
     Compute the dot product of two lists:
     >>> a = [1, 2, 3]
     >>> b = [4, 5, 6]
-    >>> dot_product(a, b)
-    32.0
-
-    Compute the dot product of two tuples:
-    >>> a = (1, 2, 3)
-    >>> b = (4, 5, 6)
-    >>> dot_product(a, b)
-    32.0
-
-    Compute the dot product of two numpy arrays:
-    >>> a = np.array([1, 2, 3])
-    >>> b = np.array([4, 5, 6])
     >>> dot_product(a, b)
     32.0
     """

--- a/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/src/{{ cookiecutter.package_dir_name }}/calculator.py
@@ -2,5 +2,42 @@ import numpy as np
 
 
 def dot_product(a, b):
-    """Calculate the dot product of two vectors."""
-    return np.dot(a, b)
+    """Compute the dot product of two vectors of any size.
+
+    Ensure that the inputs of a and b are of the same size.
+    The supported types are Python list, Python tuple, and NumyPy array.
+
+    Parameters
+    ----------
+    a : array_like
+        The first input of vector.
+    b : array_like
+        The second input vector.
+
+    Returns
+    -------
+    float
+        The dot product of the two vectors.
+
+    Examples
+    --------
+
+    Compute the dot product of two lists:
+    >>> a = [1, 2, 3]
+    >>> b = [4, 5, 6]
+    >>> dot_product(a, b)
+    32.0
+
+    Compute the dot product of two tuples
+    >>> a = (1, 2, 3)
+    >>> b = (4, 5, 6)
+    >>> dot_product(a, b)
+    32.0
+
+    Compute the dot product of two numpy arrays:
+    >>> a = np.array([1, 2, 3])
+    >>> b = np.array([4, 5, 6])
+    >>> dot_product(a, b)
+    32.0
+    """
+    return float(np.dot(a, b))

--- a/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
@@ -1,35 +1,70 @@
+import numpy as np
 import pytest
-from {{cookiecutter.package_dir_name}} import calculator
+from {{cookiecutter.package_dir_name}} import calculator as calc
 
 
-def test_dot_product_2D():
-    """Test the dot product function with 2D vectors."""
+def test_dot_product_2D_list():
     a = [1, 2]
     b = [3, 4]
-    expected = 11
-    actual = calculator.dot_product(a, b)
+    expected = 11.0
+    actual = calc.dot_product(a, b)
     assert actual == expected
 
 
-def test_dot_product_3D():
-    """Test the dot product function with 3D vectors."""
+def test_dot_product_3D_list():
     a = [1, 2, 3]
     b = [4, 5, 6]
-    expected = 32
-    actual = calculator.dot_product(a, b)
+    expected = 32.0
+    actual = calc.dot_product(a, b)
     assert actual == expected
 
+def test_dot_product_2D_tuple():
+    a = (1, 2)
+    b = (3, 4)
+    expected = 11.0
+    actual = calc.dot_product(a, b)
+    assert actual == expected
+
+
+def test_dot_product_3D_tuple():
+    a = (1, 2, 3)
+    b = (4, 5, 6)
+    expected = 32.0
+    actual = calc.dot_product(a, b)
+    assert actual == expected
+
+
+def test_dot_product_2D_np_array():
+    a = np.array([1, 2])
+    b = np.array([3, 4])
+    expected = 11.0
+    actual = calc.dot_product(a, b)
+    assert actual == expected
+
+
+def test_dot_product_3D_np_array():
+    a = np.array([1, 2, 3])
+    b = np.array([4, 5, 6])
+    expected = 32.0
+    actual = calc.dot_product(a, b)
+    assert actual == expected
 
 @pytest.mark.parametrize(
     "a, b, expected",
     [
-        # Test whether the doc product function works with different vector sizes
-        # 2D vectors, expect 11
-        ([1, 2], [3, 4], 11),
-        # 3D vectors, exppect 32
-        ([1, 2, 3], [4, 5, 6], 32),
+        # Test whether the dot product function works with 2D and 3D vectors
+        # C1: lists given, expect no error
+        ([1, 2], [3, 4], 11.0),
+        ([1, 2, 3], [4, 5, 6], 32.0),
+        # C2: tuples given, expect no error
+        ((1, 2), (3, 4), 11.0),
+        ((1, 2, 3), (4, 5, 6), 32.0),
+        # C3: numpy arrays, expect no error
+        (np.array([1, 2]), np.array([3, 4]), 11.0),
+        (np.array([1, 2, 3]), np.array([4, 5, 6]), 32.0),
     ]
+
 )
 def test_dot_product(a, b, expected):
-    actual = calculator.dot_product(a, b)
+    actual = calc.dot_product(a, b)
     assert actual == expected

--- a/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
@@ -53,10 +53,10 @@ def test_dot_product_3D_np_array():
     "a, b, expected",
     [
         # Test whether the dot product function works with 2D and 3D vectors
-        # C1: lists given, expect no error
+        # C1: lists, expect no error
         ([1, 2], [3, 4], 11.0),
         ([1, 2, 3], [4, 5, 6], 32.0),
-        # C2: tuples given, expect no error
+        # C2: tuples, expect no error
         ((1, 2), (3, 4), 11.0),
         ((1, 2, 3), (4, 5, 6), 32.0),
         # C3: numpy arrays, expect no error

--- a/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
@@ -53,13 +53,13 @@ def test_dot_product_3D_np_array():
     "a, b, expected",
     [
         # Test whether the dot product function works with 2D and 3D vectors
-        # C1: lists, expect no error
+        # C1: lists, expect correct float output
         ([1, 2], [3, 4], 11.0),
         ([1, 2, 3], [4, 5, 6], 32.0),
-        # C2: tuples, expect no error
+        # C2: tuples, expect correct float output
         ((1, 2), (3, 4), 11.0),
         ((1, 2, 3), (4, 5, 6), 32.0),
-        # C3: numpy arrays, expect no error
+        # C3: numpy arrays, expect correct float output
         (np.array([1, 2]), np.array([3, 4]), 11.0),
         (np.array([1, 2, 3]), np.array([4, 5, 6]), 32.0),
     ]

--- a/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
+++ b/{{ cookiecutter.github_repo_name }}/tests/test_calculator.py
@@ -18,37 +18,6 @@ def test_dot_product_3D_list():
     actual = calc.dot_product(a, b)
     assert actual == expected
 
-def test_dot_product_2D_tuple():
-    a = (1, 2)
-    b = (3, 4)
-    expected = 11.0
-    actual = calc.dot_product(a, b)
-    assert actual == expected
-
-
-def test_dot_product_3D_tuple():
-    a = (1, 2, 3)
-    b = (4, 5, 6)
-    expected = 32.0
-    actual = calc.dot_product(a, b)
-    assert actual == expected
-
-
-def test_dot_product_2D_np_array():
-    a = np.array([1, 2])
-    b = np.array([3, 4])
-    expected = 11.0
-    actual = calc.dot_product(a, b)
-    assert actual == expected
-
-
-def test_dot_product_3D_np_array():
-    a = np.array([1, 2, 3])
-    b = np.array([4, 5, 6])
-    expected = 32.0
-    actual = calc.dot_product(a, b)
-    assert actual == expected
-
 @pytest.mark.parametrize(
     "a, b, expected",
     [


### PR DESCRIPTION
Closes https://github.com/Billingegroup/scikit-package/issues/308

Added docstrings for the `dot_product` function. I have noticed that this function not only work with multiple array sizes, but also various `array_like` types. Hence, added a few more test cases. 