### PR TITLE
refactor: use global variable for skpkg github URL in app.py

### DIFF
--- a/news/package-create-refactor.rst
+++ b/news/package-create-refactor.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news added: just refactored the package create command recommended bg @sbillinge
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -2,23 +2,25 @@ import subprocess
 from argparse import ArgumentParser
 
 
+SKPKG_GITHUB_URL = "https://github.com/Billingegroup/scikit-package"
+
 def create(package_type):
     if package_type == "workspace":
         run_cookiecutter(
-            "https://github.com/Billingegroup/scikit-package-workspace"
+            f"{SKPKG_GITHUB_URL}-workspace"
         )
     elif package_type == "system":
         run_cookiecutter(
-            "https://github.com/Billingegroup/scikit-package-system"
+            f"{SKPKG_GITHUB_URL}-system"
         )
     elif package_type == "public":
-        run_cookiecutter("https://github.com/Billingegroup/scikit-package")
+        run_cookiecutter(SKPKG_GITHUB_URL)
 
 
 def update():
     # FIXME: Implement the update command.
     # As of now it does the same as the create command.
-    run_cookiecutter("https://github.com/Billingegroup/scikit-package")
+    run_cookiecutter("")
 
 
 def run_cookiecutter(repo_url):

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -16,7 +16,7 @@ def create(package_type):
 def update():
     # FIXME: Implement the update command.
     # As of now it does the same as the create command.
-    run_cookiecutter("")
+    run_cookiecutter(SKPKG_GITHUB_URL)
 
 
 def run_cookiecutter(repo_url):

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,18 +1,14 @@
 import subprocess
 from argparse import ArgumentParser
 
-
 SKPKG_GITHUB_URL = "https://github.com/Billingegroup/scikit-package"
+
 
 def create(package_type):
     if package_type == "workspace":
-        run_cookiecutter(
-            f"{SKPKG_GITHUB_URL}-workspace"
-        )
+        run_cookiecutter(f"{SKPKG_GITHUB_URL}-workspace")
     elif package_type == "system":
-        run_cookiecutter(
-            f"{SKPKG_GITHUB_URL}-system"
-        )
+        run_cookiecutter(f"{SKPKG_GITHUB_URL}-system")
     elif package_type == "public":
         run_cookiecutter(SKPKG_GITHUB_URL)
 


### PR DESCRIPTION
Closes https://github.com/Billingegroup/scikit-package/issues/307

Setup global variable of `SKPKG_GITHUB_URL = "https://github.com/Billingegroup/scikit-package"` at the top of the file, suggested by @sbillinge 