### PR TITLE
style: typos in docs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -44,7 +44,7 @@ The steps are divided into five levels of shareability and complexity, allowing 
 - Level 5, ``public``, is the final step, where the source code is uploaded online so that anyone in the world can install the package, sourced from PyPI or conda-forge.
 
 
-Who are using ``scikit-package``?
+Who is using ``scikit-package``?
 ----------------------------------
 
 The full list of packages is as follows:

--- a/doc/source/new-project-guide/level-2-tutorial.rst
+++ b/doc/source/new-project-guide/level-2-tutorial.rst
@@ -47,7 +47,7 @@ This is the content of ``file_one.py``:
 .. code-block:: python
 
     # file_one.py
-    from calculator import dot_product
+    from shared_functions import dot_product
 
     v1 = [1, 2]
     v2 = [3, 4]
@@ -58,15 +58,15 @@ This is the content of ``file_two.py``:
 .. code-block:: python
 
     # file_two.py
-    import calculator
+    import shared_functions
 
     v3 = [5, 6]
     v4 = [7, 8]
-    print(calculator.dot_product(v3, v4))  # returns 83
+    print(shared_functions.dot_product(v3, v4))  # returns 83
 
 .. note::
 
-    Notice that in ``file_two.py``, you can import the entire module ``calculator`` and use the function ``dot_product`` by prefixing it with the module name. Importing a modele is a good practice when you have multiple functions in the same file. This way, you can avoid name conflicts and make your code more readable.
+    Notice that in ``file_two.py``, you can import the entire module ``shared_functions`` and use the function ``dot_product`` by prefixing it with the module name. Importing a modele is a good practice when you have multiple functions in the same file. This way, you can avoid name conflicts and make your code more readable.
 
 Are you having trouble running the code?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
`calculator.py` didn't get changed to `shared_functions.py` in the docs