### PR TITLE
docs: add tutorial on GitHub Actions to run `news-check` CI

### DIFF
--- a/doc/source/frequently-asked-questions.rst
+++ b/doc/source/frequently-asked-questions.rst
@@ -39,10 +39,6 @@ How do I ignore words/lines/files in automatic spelling checks in pre-commit?
 
 .. include:: snippets/codespell-ignore.rst
 
-
-How do I ignore words/lines/files in automatic spelling checks in pre-commit?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
 Project setup
 -------------
 

--- a/doc/source/frequently-asked-questions.rst
+++ b/doc/source/frequently-asked-questions.rst
@@ -39,6 +39,10 @@ How do I ignore words/lines/files in automatic spelling checks in pre-commit?
 
 .. include:: snippets/codespell-ignore.rst
 
+
+How do I ignore words/lines/files in automatic spelling checks in pre-commit?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Project setup
 -------------
 

--- a/doc/source/new-project-guide/level-5-tutorial.rst
+++ b/doc/source/new-project-guide/level-5-tutorial.rst
@@ -196,14 +196,33 @@ Setup Codecov token for GitHub repository
 
 .. include:: snippets/github-codecov-setup.rst
 
-Add news items in your pull request
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Allow GitHub Actions to write comments in PRs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-If you are happy with the changes, let's merge the code from ``skpkg-migration`` to the ``main`` branch.
+As you will see in the next section, we'd like to have GitHub Actions write comments such as warnings. Let's specify the permissions in the GitHub repository settings by following the steps below.
 
-However, before merging to ``main``, you are required to add a news item for the changes made in the PR. This is to ensure that the changes are documented in the ``CHANGELOG.rst`` when you create a new release as shown in https://billingegroup.github.io/scikit-package/release.html for example.
+#. Visit the ``Settings`` page of the GitHub repository.
 
-We require that each PR includes a news item as a ``<branch-name>.rst`` file under the ``news`` directory.
+#. Click on ``Actions`` in the left sidebar.
+
+#. Click on ``General`` in the left sidebar.
+
+#. Scroll down to the ``Workflow permissions`` section.
+
+#. Select ``Read and write permissions``.
+
+#. Done!
+
+Add news items in the GitHub pull request
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Before merging to ``main``, we require that each PR includes a file documenting the changes under ``\news``. This ensures that the changes are documented in the ``CHANGELOG.rst`` when you create a new release, as shown in https://billingegroup.github.io/scikit-package/release.html, for example.
+
+    .. important::
+
+        If no news file is created for this PR, the CI will not only fail but also write a comment to remind you to create a news file. Recall we granted GitHub Actions permission to write comments in the PR in the previous section.
+
+Let's create a news item for the changes made in this PR.
 
 #. Get the latest updates from the remote GitHub repository.
 

--- a/news/news-permission-workflow-instruction.rst
+++ b/news/news-permission-workflow-instruction.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add instrunctions on how to setup write permission in GitHub workflows at the org and repository level.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes #292 