### PR TITLE
refactor: remove the import of `extend_path` from `pkgutil` in `diffpy/__init__.py`

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -24,14 +24,7 @@ def __gen_init__(module_name):
 # See LICENSE.rst for license information.
 #
 ##############################################################################
-\"\"\"Blank namespace package for module {module_name}.\"\"\"
 
-
-from pkgutil import extend_path
-
-__path__ = extend_path(__path__, __name__)
-
-# End of file
 """
     return __init__
 

--- a/news/remove-namespace-extra.rst
+++ b/news/remove-namespace-extra.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* Remove the import of extend_path from pkgutil in diffpy/__init__.py in post_gen_hook.py when creating a new project with with the project name of <org-name>.<project-name>.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes #349 

Tested in `labpdfproc`: https://github.com/diffpy/diffpy.labpdfproc/pull/176#issuecomment-2836057100