### PR TITLE
docs: define clear roles for "owner" and "maintainer" in the documentation

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -10,7 +10,7 @@
   "conda_pypi_package_dist_name": "{{ cookiecutter.project_name|replace(' ', '-')|lower }}",
   "package_dir_name": "{{ cookiecutter.project_name|replace(' ', '_')|replace('-', '_')|lower }}",
   "project_short_description": "Python package for doing science.",
-  "keywords": "diffraction, PDF, X-ray, neutron",
+  "project_keywords": "diffraction, PDF, X-ray, neutron",
   "minimum_supported_python_version": "3.11",
   "maximum_supported_python_version": "3.13",
   "project_needs_c_code_compiled": ["No", "Yes"],

--- a/doc/source/conda-forge-release-guide.rst
+++ b/doc/source/conda-forge-release-guide.rst
@@ -75,12 +75,12 @@ Now, you have ``recipes/<package-name>/meta.yaml`` generated.
 .. important::
    - For a pure python package, have you removed the ``build`` section under the ``requirements``? See https://github.com/conda-forge/diffpy.utils-feedstock/blob/main/recipe/meta.yaml for example.
 
-   - Have you double-checked the license file name in ``meta.yaml`` against the license files in the project repository. If you are unsure, please confirm with the repository owner (Prof. Billinge).
+   - Have you double-checked the license file name in ``meta.yaml`` against the license files in the project repository. If you are unsure, please confirm with the repository maintainer.
 
 
 .. _conda-forge-recipe-upload:
 
-2. Upload ``meta.yaml`` to conda-forge for initial review
+1. Upload ``meta.yaml`` to conda-forge for initial review
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 1. Fork https://github.com/conda-forge/staged-recipes and clone your forked repository
@@ -145,7 +145,7 @@ First, we will copy the ``SHA256`` value from `pypi.org <http://pypi.org>`_:
 
 #. Create a PR to ``main``, complete the relevant checklists generated in the PR comment.
 
-#. Wait for the CI to pass and tag Project Owner for review.
+#. Wait for the CI to pass and tag relevant maintainer(s) for review.
 
 #. Once the PR is merged, in 20 to 30 minutes, verify the latest conda-forge package version from the README badge or by visiting ``https://anaconda.org/conda-forge/<package-name>``. i.e.g, ``https://anaconda.org/conda-forge/diffpy.utils``.
 

--- a/doc/source/conda-forge-release-guide.rst
+++ b/doc/source/conda-forge-release-guide.rst
@@ -75,7 +75,7 @@ Now, you have ``recipes/<package-name>/meta.yaml`` generated.
 .. important::
    - For a pure python package, have you removed the ``build`` section under the ``requirements``? See https://github.com/conda-forge/diffpy.utils-feedstock/blob/main/recipe/meta.yaml for example.
 
-   - Have you double-checked the license file name in ``meta.yaml`` against the license files in the project repository. If you are unsure, please confirm with the repository maintainer.
+   - Have you double-checked the license file name in ``meta.yaml`` against the license files in the project repository. If you are unsure, please confirm with the project owner.
 
 
 .. _conda-forge-recipe-upload:

--- a/doc/source/frequently-asked-questions.rst
+++ b/doc/source/frequently-asked-questions.rst
@@ -128,7 +128,7 @@ Release
 How can I change who is authorized to release a package?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In ``.github/workflows/build-wheel-release-upload.yml``, modify ``github_admin_username`` to the desired GitHub username. This username will be able to authorize the release by pushing the tag as instructed :ref:`here <release-instructions-project-owner>`.
+In ``.github/workflows/build-wheel-release-upload.yml``, modify ``github_admin_username`` to the desired GitHub username. This username will be able to authorize the release by pushing the tag as instructed :ref:`here <release-instructions-project-maintainer>`.
 
 How is the package version set and retrieved?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -306,7 +306,7 @@ GitHub workflow
 I am new to GitHub. Why do we use Git/GitHub?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-GitHub allows multiple contributors to work on a software project simultaneously under an organization like ``Billingegroup`` or ``diffpy``. There are two primary needs. First, we want to ensure that any changes under this organization are reviewed by the organization's project owner. Second, we want to ensure we add new changes from the latest version of the code, particularly when working with multiple contributors across different time zones. Hence, we use GitHub to serve the needs with a specific workflow below. Please see below for an overview of the GitHub workflow.
+GitHub allows multiple contributors to work on a software project simultaneously under an organization like ``Billingegroup`` or ``diffpy``. There are two primary needs. First, we want to ensure that any changes under this organization are reviewed by the organization's project maintainer. Second, we want to ensure we add new changes from the latest version of the code, particularly when working with multiple contributors across different time zones. Hence, we use GitHub to serve the needs with a specific workflow below. Please see below for an overview of the GitHub workflow.
 
 .. _github-workflow-overview:
 

--- a/doc/source/migration-guide.rst
+++ b/doc/source/migration-guide.rst
@@ -157,7 +157,7 @@ Your package will most likely have failed pre-commit hooks. We will manually fix
 
 #. For each `flake8` branch, create a PR request to ``package``. Since you are fixing flake8 errors, the commit message can be ``skpkg: Fix flake8 <readable-error-type> errors`` and the pull request title can be ``skpkg: Fix flake8 <readable-error-type> errors``.
 
-#. For each PR, either the project owner or the maintainer will review the PR and merge it to ``package``. If you are the project owner, you can merge the PR yourself.
+#. For each PR, either the project maintainer or the maintainer will review the PR and merge it to ``package``. If you are the project maintainer, you can merge the PR yourself.
 
 
 1.4. Setup pre-commit hooks locally
@@ -315,7 +315,7 @@ Here, you will first check the correct folder structure. If the project structur
 2.5. Move rest of text files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Files showing as (2) "deleted" upon git status are in the main repo but not in the scikit-package repo. We took care of most of these by moving over the src tree, but let's do the rest now. Go down the list and for <filename> in the ``git status`` "delete" files type ``cp -n ../<filepath>/<filename> ./<target_filepath>``. Do not move files that we do not want. If you are unsure, please confirm with Project Owner.
+#. Files showing as (2) "deleted" upon git status are in the main repo but not in the scikit-package repo. We took care of most of these by moving over the src tree, but let's do the rest now. Go down the list and for <filename> in the ``git status`` "delete" files type ``cp -n ../<filepath>/<filename> ./<target_filepath>``. Do not move files that we do not want. If you are unsure, please confirm with Project maintainer.
 
 #. Files that have been (3) modified exist in both places and need to be merged **manually**. Do these one at a time. Differences will show up. Select anything you want to inherit from the file in the main repo. For example, you want to copy useful information such as LICENSE and README files.
 

--- a/doc/source/migration-guide.rst
+++ b/doc/source/migration-guide.rst
@@ -55,7 +55,7 @@ Here, let's first standarlize your package so that itis ``PEP8`` and ``PEP256`` 
 
 #. Fork the repository that you want to standarlize from the GitHub website under your GitHub account.
 
-    If you are the owner of the repository, you can skip this step.
+    If you are the maintainer of the repository, you can skip this step.
 
 #. Type ``git clone <https://github.com/<username>/<project-name>`` and ``cd <project-name>``.
 
@@ -157,7 +157,7 @@ Your package will most likely have failed pre-commit hooks. We will manually fix
 
 #. For each `flake8` branch, create a PR request to ``package``. Since you are fixing flake8 errors, the commit message can be ``skpkg: Fix flake8 <readable-error-type> errors`` and the pull request title can be ``skpkg: Fix flake8 <readable-error-type> errors``.
 
-#. For each PR, the project owner will review the PR and merge it to ``package``. If you are the project owner, you can merge the PR yourself.
+#. For each PR, the project maintainer will review the PR and merge it to ``package``. If you are the project maintainer, you can merge the PR yourself.
 
 
 1.4. Setup pre-commit hooks locally
@@ -187,7 +187,7 @@ Here, you will first check the correct folder structure. If the project structur
 
 .. Attention:: Please read the following carefully before proceeding:
 
-    - Do NOT delete/remove any files before confirming that it is absolutely unnecessary. If you are unsure, contact the project owner first.
+    - Do NOT delete/remove any files before confirming that it is absolutely unnecessary. If you are unsure, contact the project maintainer first.
 
     - Do NOT delete project-specific content such as project descriptions in README, license information, authors, tutorials, examples.
 
@@ -315,7 +315,7 @@ Here, you will first check the correct folder structure. If the project structur
 2.5. Move rest of text files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Files showing as (2) "deleted" upon git status are in the main repo but not in the scikit-package repo. We took care of most of these by moving over the src tree, but let's do the rest now. Go down the list and for <filename> in the ``git status`` "delete" files type ``cp -n ../<filepath>/<filename> ./<target_filepath>``. Do not move files that we do not want. If you are unsure, please confirm with the project owner or maintainer(s).
+#. Files showing as (2) "deleted" upon git status are in the main repo but not in the scikit-package repo. We took care of most of these by moving over the src tree, but let's do the rest now. Go down the list and for <filename> in the ``git status`` "delete" files type ``cp -n ../<filepath>/<filename> ./<target_filepath>``. Do not move files that we do not want. If you are unsure, please confirm with the project maintainer.
 
 #. Files that have been (3) modified exist in both places and need to be merged **manually**. Do these one at a time. Differences will show up. Select anything you want to inherit from the file in the main repo. For example, you want to copy useful information such as LICENSE and README files.
 

--- a/doc/source/migration-guide.rst
+++ b/doc/source/migration-guide.rst
@@ -157,7 +157,7 @@ Your package will most likely have failed pre-commit hooks. We will manually fix
 
 #. For each `flake8` branch, create a PR request to ``package``. Since you are fixing flake8 errors, the commit message can be ``skpkg: Fix flake8 <readable-error-type> errors`` and the pull request title can be ``skpkg: Fix flake8 <readable-error-type> errors``.
 
-#. For each PR, either the project owner or the maintainer will review the PR and merge it to ``package``. If you are the project owner, you can merge the PR yourself.
+#. For each PR, the project owner will review the PR and merge it to ``package``. If you are the project owner, you can merge the PR yourself.
 
 
 1.4. Setup pre-commit hooks locally
@@ -187,7 +187,7 @@ Here, you will first check the correct folder structure. If the project structur
 
 .. Attention:: Please read the following carefully before proceeding:
 
-    - Do NOT delete/remove any files before confirming that it is absolutely unnecessary. Create an issue or contact the maintainer.
+    - Do NOT delete/remove any files before confirming that it is absolutely unnecessary. If you are unsure, contact the project owner first.
 
     - Do NOT delete project-specific content such as project descriptions in README, license information, authors, tutorials, examples.
 

--- a/doc/source/migration-guide.rst
+++ b/doc/source/migration-guide.rst
@@ -157,7 +157,7 @@ Your package will most likely have failed pre-commit hooks. We will manually fix
 
 #. For each `flake8` branch, create a PR request to ``package``. Since you are fixing flake8 errors, the commit message can be ``skpkg: Fix flake8 <readable-error-type> errors`` and the pull request title can be ``skpkg: Fix flake8 <readable-error-type> errors``.
 
-#. For each PR, either the project maintainer or the maintainer will review the PR and merge it to ``package``. If you are the project maintainer, you can merge the PR yourself.
+#. For each PR, either the project owner or the maintainer will review the PR and merge it to ``package``. If you are the project owner, you can merge the PR yourself.
 
 
 1.4. Setup pre-commit hooks locally
@@ -315,7 +315,7 @@ Here, you will first check the correct folder structure. If the project structur
 2.5. Move rest of text files
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-#. Files showing as (2) "deleted" upon git status are in the main repo but not in the scikit-package repo. We took care of most of these by moving over the src tree, but let's do the rest now. Go down the list and for <filename> in the ``git status`` "delete" files type ``cp -n ../<filepath>/<filename> ./<target_filepath>``. Do not move files that we do not want. If you are unsure, please confirm with Project maintainer.
+#. Files showing as (2) "deleted" upon git status are in the main repo but not in the scikit-package repo. We took care of most of these by moving over the src tree, but let's do the rest now. Go down the list and for <filename> in the ``git status`` "delete" files type ``cp -n ../<filepath>/<filename> ./<target_filepath>``. Do not move files that we do not want. If you are unsure, please confirm with the project owner or maintainer(s).
 
 #. Files that have been (3) modified exist in both places and need to be merged **manually**. Do these one at a time. Differences will show up. Select anything you want to inherit from the file in the main repo. For example, you want to copy useful information such as LICENSE and README files.
 

--- a/doc/source/new-project-guide/level-4-tutorial.rst
+++ b/doc/source/new-project-guide/level-4-tutorial.rst
@@ -26,10 +26,6 @@ Initiate a project with ``scikit-package``
 
 #. Answer the following questions:
 
-    :project_name: (my-project)
-
-    :github_username_or_orgname: (billingegroup)
-
     :github_repo_name: (my-project)
 
     :conda_pypi_package_dist_name: (my-project)
@@ -37,6 +33,28 @@ Initiate a project with ``scikit-package``
     :package_dir_name: (my_project)
 
     :maintainer_name: (Simon Billinge)
+
+
+#. Answer the following questions:
+
+    .. list-table::
+       :header-rows: 1
+       :widths: 25 75
+
+       * - Field
+         - Description and example
+       * - project_name
+         - The project name displayed on README. e.g., my-package
+       * - github_username_or_orgname
+         - The GitHub username or organization name, e.g., sbillinge or billingegroup
+       * - github_repo_name
+         - The GitHub repository name. Use ``name-with-hypens``. e.g., my-package
+       * - conda_pypi_package_dist_name
+         - The name displayed on PyPI and conda-forge. Use ``name-with-hypens``. e.g., my-package
+       * - package_dir_name
+         - The name of the package directory under ``src``. Use ``name_with_underscores``. e.g., my_package
+       * - contributors
+         - The contributors involved in the project. e.g., Sangjoon Lee, Simon Billinge
 
 
 #. ``cd`` into the project directory created by the ``package create`` command above:

--- a/doc/source/new-project-guide/level-5-tutorial.rst
+++ b/doc/source/new-project-guide/level-5-tutorial.rst
@@ -100,11 +100,11 @@ Go to your project directory
          - The maximum supported Python version
            e.g. |PYTHON_MAX_VERSION|
        * - needs_c_code_compiled
-         - Indicates whether C code compilation is required.
-           For pure Python packages, use ``No``
+         - Specifies whether C code compilation is required.
+           For pure Python packages, the default value is ``No``.
        * - has_gui_tests
-         - Indicates whether GUI tests are included.
-           For most packages, use ``No``
+         - Specifies whether GUI tests are included.
+           For most packages, the default value is ``No``.
 
 
 #. Enter the Level 5 project.

--- a/doc/source/new-project-guide/level-5-tutorial.rst
+++ b/doc/source/new-project-guide/level-5-tutorial.rst
@@ -48,41 +48,64 @@ Go to your project directory
 
         package create public
 
-.. _level-5-user-input:
-
 #. Answer the following questions:
 
-    :proj_owner_name: e.g., Simon J. L. Billinge
+    .. list-table::
+       :header-rows: 1
+       :widths: 25 75
 
-    :proj_owner_email: e.g., sbillinge@columbia.edu
+       * - Field
+         - Description and example
+       * - maintainer_name
+         - The name of the project maintainer.
+           e.g., Simon Billinge
+       * - maintainer_email
+         - The maintainer's email address.
+           e.g., sbillinge@columbia.edu
+       * - maintainer_github_username
+         - The maintainer's GitHub username.
+           e.g., sbillinge
+       * - contributors
+         - Individuals or groups contributing to the project.
+           e.g., Sangjoon Lee, Simon Billinge, Billinge Group members
+       * - license_holders
+         - The license holders listed in ``LICENSE.rst``.
+           e.g., The Trustees of Columbia University in the City of New York
+       * - project_name
+         - The name displayed in the ``README.rst`` and documentation.
+           Use ``name-with-hyphens`` e.g., ``my-package``.
+           To support namespace imports, see :ref:`FAQ <faq-project-setup-namespace>`
+       * - github_username_or_orgname
+         - The GitHub username or organization name.
+           e.g., sbillinge or billingegroup
+       * - github_repo_name
+         - The GitHub repository name.
+           Use ``name-with-hyphens`` e.g., my-package
+       * - conda_pypi_package_dist_name
+         - The name used for publishing to PyPI and conda-forge.
+           Use ``name-with-hyphens`` e.g., my-package
+       * - package_dir_name
+         - The name of the package directory under ``src``.
+           Use ``name_with_underscores`` e.g., my_package
+       * - project_short_description
+         - A brief description of the project, shown in ``pyproject.toml``.
+           e.g., A Python package standard for scientific code
+       * - project_keywords
+         - A list of keywords included in ``pyproject.toml``.
+           e.g., PDF, diffraction, neutron, x-ray
+       * - min_python_version
+         - The minimum supported Python version.
+           e.g. |PYTHON_MIN_VERSION|
+       * - max_python_version
+         - The maximum supported Python version
+           e.g. |PYTHON_MAX_VERSION|
+       * - needs_c_code_compiled
+         - Indicates whether C code compilation is required.
+           For pure Python packages, use ``No``
+       * - has_gui_tests
+         - Indicates whether GUI tests are included.
+           For most packages, use ``No``
 
-    :proj_owner_gh_username: e.g., sbillinge
-
-    :contributors: e.g., Billinge Group members and community contributors.
-
-    :license_holders: e.g., The Trustees of Columbia University in the City of New York.
-
-    :proj_name: For namespace packages, use e.g., ``<org.project-name>``.
-
-    :gh_org: The GitHub organization name or owner's GitHub username. e.g., billingegroup or sbillinge.
-
-    :gh_repo_name: e.g., my-package. The repository name of the project displayed on GitHub.
-
-    :package_dist_name: The name in the package distribution in PyPI and conda-forge.
-
-    :package_dir_name: The name of the package directory under ``src``.
-
-    :proj_short_description: e.g., A Python package standard and generator for scientific code.
-
-    :keywords: Each word is separated by a comma and a space. e.g., ``pdf, diffraction, neutron, x-ray``.
-
-    :min_python_version: The minimum Python version for package distribution.
-
-    :max_python_version: The maximum Python version for package distribution.
-
-    :needs_c_code_compiled: Whether C/C++ is compiled to build the package. For a pure Python package, type ``1`` to select ``No``.
-
-    :has_gui_tests: Whether the package runs headless testing in GitHub CI. If your package does not contain a GUI, type ``1`` to select ``No``.
 
 #. Enter the Level 5 project.
 

--- a/doc/source/pypi-release-guide.rst
+++ b/doc/source/pypi-release-guide.rst
@@ -30,10 +30,10 @@ PyPI/GitHub release
 
 #. Proceed to the next section.
 
-Instructions for Project Owner for PyPI/GitHub release for the first time
+Instructions for project maintainer for PyPI/GitHub release for the first time
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. _release-instructions-project-owner:
+.. _release-instructions-project-maintainer:
 
 #. Review the release GitHub issue created in the previous step.
 
@@ -41,7 +41,7 @@ Instructions for Project Owner for PyPI/GitHub release for the first time
 
 #. Setup GitHub pages at the repository level by following the instructions in Appendix :ref:`3 <gh-pages-setup>`.
 
-#. Confirm the ``github_admin_username`` section in ``.github/workflows/build-wheel-release-upload.yml`` is that of the project owner.
+#. Confirm the ``github_admin_username`` section in ``.github/workflows/build-wheel-release-upload.yml`` is that of the project maintainer.
 
 #. In your terminal, run ``git checkout main && git pull upstream main`` to sync with the main branch.
 
@@ -115,7 +115,7 @@ Add the generated token to GitHub:
 Appendix 2. Setup ``PAT_TOKEN`` to allow GitHub Actions to compile ``CHANGELOG.rst``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Recall that dring a release (not pre-release) process, the GitHub Actions workflow compiles the news items in the ``CHANGELOG.rst`` file in the ``main`` branch. Hence, the GitHub workflow needs to link with this privilege through a personal access token (PAT) of the project owner.
+Recall that dring a release (not pre-release) process, the GitHub Actions workflow compiles the news items in the ``CHANGELOG.rst`` file in the ``main`` branch. Hence, the GitHub workflow needs to link with this privilege through a personal access token (PAT) of the project maintainer.
 
 1. Visit https://github.com/settings/tokens
 

--- a/doc/source/snippets/github-codecov-setup.rst
+++ b/doc/source/snippets/github-codecov-setup.rst
@@ -5,7 +5,7 @@ For each PR, we use ``Codecov`` to report the test coverage percentage change as
 .. image:: ./img/codecov-pr.png
    :alt: codecov-in-pr-comment
 
-To do so, the repository owner needs to provide a ``CODECOV_TOKEN``.  Please follow the step-by-step guide below.
+To do so, the repository maintainer needs to provide a ``CODECOV_TOKEN``.  Please follow the step-by-step guide below.
 
 #. Ensure your GitHub repository is public.
 

--- a/news/owner-maintainer-doc.rst
+++ b/news/owner-maintainer-doc.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* no news added: adopt project_owner to maintainer and enhance tables
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/owner-maintainer-doc.rst
+++ b/news/owner-maintainer-doc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* no news added: adopt project_owner to maintainer and enhance tables
+* Define clear roles for the owner and maintainer. The maintainer has merge and release rights, while the owner oversees the project, similar to a Principal Investigator (PI) in a research group.
 
 **Changed:**
 

--- a/{{ cookiecutter.github_repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.github_repo_name }}/pyproject.toml
@@ -12,7 +12,7 @@ maintainers = [
   { name="{{ cookiecutter.maintainer_name }}", email="{{ cookiecutter.maintainer_email }}" },
 ]
 description = "{{ cookiecutter.project_short_description }}"
-{%- set keywords_list = (cookiecutter.keywords.split(',') if cookiecutter.keywords.strip() else []) -%}
+{%- set keywords_list = (cookiecutter.project_keywords.split(',') if cookiecutter.project_keywords.strip() else []) -%}
 {%- set ns = namespace(keywords_trim = []) -%}
 {%- for keyword in keywords_list -%}
 {%- set _ = ns.keywords_trim.append(keyword.strip()) -%}


### PR DESCRIPTION
Addresses https://github.com/Billingegroup/scikit-package/issues/372 (rename owner to maintainter)
Closes https://github.com/Billingegroup/scikit-package/issues/362

Also, fixed the following from (can't wrap words outside of the page)

<img width="889" alt="Screenshot 2025-05-03 at 5 02 05 PM" src="https://github.com/user-attachments/assets/7482597c-1f40-4bd8-a0b1-613cf49525da" />

to

<img width="366" alt="Screenshot 2025-05-03 at 5 53 20 PM" src="https://github.com/user-attachments/assets/5c9057e8-4f1d-44ba-a9fc-b530962b1a78" />
