### PR TITLE
refactor: update `GITHUB_ADMIN_USERNAME` to `MAINTAINER_GITHUB_USERNAME` in host gen hook

### DIFF
--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -138,7 +138,7 @@ def update_workflow():
     LOCAL_WORKFLOW_DIR = ROOT / ".github" / "workflows"
 
     workflow_input = {"PROJECT": "{{ cookiecutter.project_name }}",
-                      "GITHUB_ADMIN_USERNAME": "{{ cookiecutter.maintainer_github_username }}",
+                      "MAINTAINER_GITHUB_USERNAME": "{{ cookiecutter.maintainer_github_username }}",
                       "C_EXTENSION": str("{{ cookiecutter.project_needs_c_code_compiled }}"=="Yes").lower(),
                       "HEADLESS": str("{{ cookiecutter.project_has_gui_tests }}"=="Yes").lower(),
                       "VERSION": "v0"}

--- a/news/workflow-dynamic.rst
+++ b/news/workflow-dynamic.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* Update GITHUB_ADMIN_USERNAME to MAINTAINER_GITHUB_USERNAME in post_gen_hook.py to dynamically generate GitHub workflow files.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/workflow-dynamic.rst
+++ b/news/workflow-dynamic.rst
@@ -4,7 +4,7 @@
 
 **Changed:**
 
-* Update GITHUB_ADMIN_USERNAME to MAINTAINER_GITHUB_USERNAME in post_gen_hook.py to dynamically generate GitHub workflow files.
+* <news item>
 
 **Deprecated:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Update GITHUB_ADMIN_USERNAME to MAINTAINER_GITHUB_USERNAME in post_gen_hook.py to dynamically generate GitHub workflow files.
 
 **Security:**
 


### PR DESCRIPTION
This change is required to dynamically populate the workflow template files in our release-scripts.

@sbillinge ready to be merged.