### PR TITLE
docs: fix image relative URLs, use guilabel for clickable buttons in instructions

### DIFF
--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -1,4 +1,0 @@
-Examples
-========
-
-Add Level 4, 5, examples here.

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -103,6 +103,7 @@ Authors
 
 - Sangjoon Lee (sl5400@columbia.edu)
 - Andrew Yang (ay2546@columbia.edu)
+- Caden Myers (cjm2304@columbia.edu)
 - Simon Billinge (sb2896@columbia.edu)
 
 ``scikit-package`` is developed by Billinge Group and its community contributors.

--- a/doc/source/overview.rst
+++ b/doc/source/overview.rst
@@ -11,16 +11,16 @@ Here are the 5 levels of sharing your code. We provide tutorials for each level.
 
 .. include:: snippets/5-levels-table.rst
 
-- Are you here to start a new Python project?
+⏩️ Are you here to **start** a new Python project?
 
-    If you are **new** to programming in general, we recommend you start from Levels 1-3, where you learn to reuse your scripts across files and folders without the need to install anything. Start :ref:`here <tutorials-beginner>`.
+    If you are **new** to programming in general, we recommend you start from Levels 1-3, where you learn to reuse your scripts across files and folders without the need to install anything. Start :ref:`here <level-1-2-3-tutorials>`.
 
     If you have **experience** in developing scientific code in Python, we recommend you start from Level 4, where you learn to turn your project into a lightweight Python package that can be installed locally. Start :ref:`here <level-4-tutorial>`.
 
-- Do you want to **release** your code as a fully installable Python package?
+⏩️ Do you want to **release** your code as a fully installable Python package?
 
     If your package is already developed with Level 4, and you are ready to release your package, let's learn to migrate from Level 4 to Level 5 and host documentation and release it to PyPI and conda-forge. Start :ref:`here <level-5-tutorial>`.
 
-- Do you want to explore **best practices** for developing scientific code? Start :ref:`here <billinge-group-standards>`.
+⏩️ Do you want to explore **best practices** for developing scientific code? Start :ref:`here <billinge-group-standards>`.
 
-- Do you want to migrate your existing Python package to the ``scikit-package`` Level 5 ``public`` standard? Start :ref:`here <migration-guide>`.
+⏩️ Do you want to migrate your existing Python package to the ``scikit-package`` Level 5 ``public`` standard? Start :ref:`here <migration-guide>`.

--- a/doc/source/release-guides/pypi-github.rst
+++ b/doc/source/release-guides/pypi-github.rst
@@ -18,11 +18,11 @@ Initiate a release process with GitHub issue
 
 .. _release-instructions-contributor:
 
-.. important::  Make sure you have your project is standarlized with scikit-package up to Level 5. Otherwise, please start from the Getting started page :ref:`here <getting-started>`.
+.. important::  Make sure you have your project is standarlized with ``scikit-package`` up to Level 5. Otherwise, please start from the Overview page :ref:`here <overview>`.
 
 #. In the repository, create an issue on GitHub with the "Release" option as shown below:
 
-   .. image:: ./img/release-issue.png
+   .. image:: ../img/release-issue.png
       :alt: add-personal-access-token
       :width: 600px
 
@@ -41,7 +41,7 @@ Start pre-release
 
 #. Setup GitHub pages at the repository level by following the instructions in Appendix :ref:`3 <gh-pages-setup>`.
 
-#. Confirm the ``github_admin_username`` section in ``.github/workflows/build-wheel-release-upload.yml`` is that of the project maintainer.
+#. Confirm the ``maintainer_github_username`` section in ``.github/workflows/build-wheel-release-upload.yml`` is that of the project maintainer.
 
 #. In your terminal, run ``git checkout main && git pull upstream main`` to sync with the main branch.
 
@@ -54,7 +54,7 @@ Start pre-release
       git checkout -b <version>-rc.<rc-number>
       git push upstream <version>-rc.<rc-number>
 
-#. Done! Once the tag is pushed, visit the ``Actions`` tab in the repository to monitor the CI progress.
+#. Done! Once the tag is pushed, visit the :guilabel:`Actions` tab in the repository to monitor the CI progress.
 
 #. You will see that the GitHub Actions workflow is triggered and the package is built and uploaded to PyPI and GitHub.
 
@@ -89,25 +89,25 @@ Generate a PyPI API token from ``pypi.org``:
 
 #. Visit https://pypi.org/manage/account/ and log in.
 
-#. Scroll down to the ``API tokens`` section and click ``Add API token``.
+#. Scroll down to the :guilabel:`API tokens` section and click :guilabel:`Add API token`.
 
-#. Set the ``Token name`` to ``PYPI_TOKEN``.
+#. Set the :guilabel:`Token name` to ``PYPI_TOKEN``.
 
-#. Choose the appropriate ``Scope`` for the token.
+#. Choose the appropriate :guilabel:`Scope` for the token.
 
-#. Click ``Create token`` and copy the generated token.
+#. Click :guilabel:`Create token` and copy the generated token.
 
 Add the generated token to GitHub:
 
-#. Navigate to the ``Settings`` page of the org (or repository).
+#. Navigate to the :guilabel:`Settings` page of the org (or repository).
 
-#. Click the ``Actions`` tab under ``Secrets and variables``.
+#. Click the :guilabel:`Actions` tab under :guilabel:`Secrets and variables`.
 
-#. Click ``New org secret``, name it ``PYPI_TOKEN``, and paste the token value.
+#. Click :guilabel:`New org secret`, name it ``PYPI_TOKEN``, and paste the token value.
 
 #. Done!
 
-.. image:: ./img/add-pypi-secret.png
+.. image:: ../img/add-pypi-secret.png
    :alt: add-pypi-secret
    :width: 600px
 
@@ -120,43 +120,48 @@ Recall that dring a release (not pre-release) process, the GitHub Actions workfl
 
 1. Visit https://github.com/settings/tokens
 
-2. Click ``Generate new token`` and choose the classic option.
+2. Click :guilabel:`Generate new token` and choose the classic option.
 
-3. Under ``Note``, write, "GitHub CI release"
+3. Under :guilabel:`Note`, write, "GitHub CI release"
 
 4. Set the Expiration date of the token.
 
-5. Under ``Select scopes``, check ``repo`` and ``user``.
+5. Under :guilabel:`Select scopes`, check :guilabel:`repo` and :guilabel:`user`.
 
-6. Scroll down, click ``Generate token``.
+6. Scroll down, click :guilabel:`Generate token`.
 
 7. Done!
 
-.. image:: ./img/add-personal-access-token.png
+.. image:: ../img/add-personal-access-token.png
    :alt: add-personal-access-token
    :width: 600px
 
 Copy and paste the ``PAT_TOKEN`` to your GitHub organization:
 
-1. Visit ``Settings`` in the organization.
+:guilabel:`Settings` in the organization.
 
-2. Click the ``Actions`` tab under ``Secrets and variables``.
+1. Click the :guilabel:`Actions` tab under :guilabel:`Secrets and variables`.
 
-3. Click ``New organization secret`` and add a new secret and name it as ``PAT_TOKEN``.
+2. Click :guilabel:`New organization secret` and add a new secret and name it as ``PAT_TOKEN``.
 
-4. Done!
+3. Done!
 
 .. _gh-pages-setup:
 
 Appendix 3. Host documentation online with GitHub Pages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The goal is to host the official documentation online i.g., ``https://diffpy.github.io/diffpy.utils`` using GitHub Pages.
+Let's now host the documentation online, e.g., ``https://diffpy.github.io/diffpy.utils``, using GitHub Pages.
 
-#. Visit the ``Settings`` page in your repository and and click ``pages`` under ``Code and automation``.
-#. Click ``Deploy from a branch`` under ``Source``. Below, choose ``gh-pages`` branch and ``/(root)`` and click ``Save``. See the image below.
+#. Visit :menuselection:`Settings --> Code and automation --> Pages`.
 
-   .. image:: ./img/github-pages.png
+#. Click :guilabel:`Deploy from a branch` under :guilabel:`Source`.
+
+#. Choose the :guilabel:`gh-pages` branch and :guilabel:`/(root)`
+
+#. Click :guilabel:`Save`.
+
+   .. image:: ../img/github-pages.png
       :alt: setup-github-pages-from-branch
 
 #. Done! Wait a few minutes and visit your GitHub Pages URL!

--- a/doc/source/release-guides/pypi-github.rst
+++ b/doc/source/release-guides/pypi-github.rst
@@ -51,7 +51,7 @@ Start pre-release
 
       # For pre-release, use *.*.*-rc.* e.g., 1.0.0-rc.0
       # rc stands for release candidate
-      git checkout -b <version>-rc.<rc-number>
+      git tag <version>-rc.<rc-number>
       git push upstream <version>-rc.<rc-number>
 
 #. Done! Once the tag is pushed, visit the :guilabel:`Actions` tab in the repository to monitor the CI progress.

--- a/doc/source/snippets/scikit-installation.rst
+++ b/doc/source/snippets/scikit-installation.rst
@@ -9,16 +9,16 @@ Install ``scikit-package`` with conda
 
     .. code-block:: bash
 
-        conda create -n skpkg_env scikit-package pre-commit
+        $ conda create -n skpkg_env scikit-package pre-commit
 
 #. Activate the environment:
 
     .. code-block:: bash
 
-        conda activate skpkg_env
+        $ conda activate skpkg_env
 
 #. Confirm that you have the latest version of ``scikit-package`` available on GitHub:
 
     .. code-block:: bash
 
-        pip show scikit-package
+        $ pip show scikit-package

--- a/doc/source/tutorials/level-1-2-3-tutorials.rst
+++ b/doc/source/tutorials/level-1-2-3-tutorials.rst
@@ -1,3 +1,5 @@
+.. _level-1-2-3-tutorials:
+
 (Level 1-3) Reuse code within a file, across files and folders
 ==============================================================
 
@@ -18,7 +20,7 @@ Also, ensure that Python is installed on your system. You can check this by runn
 
 .. code-block:: bash
 
-    python --version
+     $ python --version
 
 Folder structure
 ^^^^^^^^^^^^^^^^
@@ -61,13 +63,13 @@ Install ``numpy`` by running:
 
 .. code-block:: bash
 
-    pip install numpy
+     $ pip install numpy
 
 Then run
 
 .. code-block:: bash
 
-    python example_code.py
+    $ python example_code.py
 
 You should see the outputs of 11 and 83 printed.
 
@@ -185,7 +187,6 @@ In Level 3, you will learn to reuse code across multiple files and folders. You 
 Level 3. Reuse code across projects
 -----------------------------------
 
-
 Overview
 ^^^^^^^^^
 
@@ -206,7 +207,7 @@ Create a new project by running the following command:
 
 .. code-block:: bash
 
-     package create workspace
+     $ package create workspace
 
 You will then be asked to enter the ``project-name``. The default value is ``workspace-folder``.
 In this example, enter ``data-analysis-project`` as the workspace folder you are about to create.
@@ -219,7 +220,7 @@ In this example, enter ``data-analysis-project`` as the workspace folder you are
 
 .. code-block:: bash
 
-    cd data-analysis-project
+    $ cd data-analysis-project
 
 Folder structure
 ^^^^^^^^^^^^^^^^^
@@ -243,10 +244,10 @@ If you would like to add more projects, you can create a new folder under the ro
 
 .. code-block:: bash
 
-     mkdir proj-two
-     cd proj-two
-     touch __init__.py
-     touch proj_two_code.py
+     $ mkdir proj-two
+     $ cd proj-two
+     $ touch __init__.py
+     $ touch proj_two_code.py
 
 
 File descriptions
@@ -357,7 +358,7 @@ You can install the dependencies like ``numpy`` listed in ``requirements.txt`` b
 
 .. code-block:: bash
 
-    pip install -r requirements.txt
+    $ pip install -r requirements.txt
 
 Set PYTHONPATH
 ^^^^^^^^^^^^^^^
@@ -368,7 +369,7 @@ Type ``pwd`` in your command-line tool to see the current working directory.
 
 .. code-block:: bash
 
-     pwd
+     $ pwd
 
 For a macOS user, it will print something like ``/Users/macbook/downloads/dev/scikit-package/workspace_folder``.
 
@@ -377,7 +378,7 @@ Copy and paste the value while replacing ``<path-to-your-workspace-folder>`` wit
 .. code-block:: bash
 
      # For macOS/Linux user
-    export PYTHONPATH="${PYTHONPATH}:<path-to-your-workspace-folder>"
+    $ export PYTHONPATH="${PYTHONPATH}:<path-to-your-workspace-folder>"
 
      # For Windows (Powershell) user
     $env:PYTHONPATH = "$env:PYTHONPATH;<path-to-your-workspace-folder>"
@@ -388,22 +389,22 @@ To avoid retyping this command every time you open a new terminal, you can add i
 
      # For macOS/Linux:
      # bash shell
-     nano ~/.bashrc
+     $ nano ~/.bashrc
      # zsh shell
-     nano ~/.zshrc
+     $ nano ~/.zshrc
 
      # For Windows PowerShell:
-     notepad $PROFILE
+     $ notepad $PROFILE
 
 Then, add the command to set ``PYTHONPATH`` at the end of the file:
 
 .. code-block:: bash
 
      # For macOS/Linux (bash or zsh shell)
-     echo 'export PYTHONPATH="${PYTHONPATH}:/path/to/your/workspace_folder"'
+     $ echo 'export PYTHONPATH="${PYTHONPATH}:/path/to/your/workspace_folder"'
 
      # For Windows (PowerShell)
-     echo '$env:PYTHONPATH = "$env:PYTHONPATH;/path/to/your/workspace_folder"'
+     $ echo '$env:PYTHONPATH = "$env:PYTHONPATH;/path/to/your/workspace_folder"'
 
 After adding the command, restart your terminal or run the corresponding file to activate the changes through the commands below:
 
@@ -411,12 +412,12 @@ After adding the command, restart your terminal or run the corresponding file to
 
      # For macOS/Linux:
      # bash shell
-     source ~/.bash_profile
+     $ source ~/.bash_profile
      # zsh shell
-     source ~/.zshrc
+     $ source ~/.zshrc
 
      # For Windows PowerShell:
-     . $PROFILE
+     $ . $PROFILE
 
 .. note::
 

--- a/doc/source/tutorials/level-5-tutorial.rst
+++ b/doc/source/tutorials/level-5-tutorial.rst
@@ -234,15 +234,15 @@ Allow GitHub Actions to write comments in PRs
 
 As you will see in the next section, we'd like to have GitHub Actions write comments such as warnings. Let's specify the permissions in the GitHub repository settings by following the steps below.
 
-#. Visit the ``Settings`` page of the GitHub repository.
+#. Visit the :guilabel:`Settings` page of the GitHub repository.
 
-#. Click on ``Actions`` in the left sidebar.
+#. Click on :guilabel:`Actions` in the left sidebar.
 
-#. Click on ``General`` in the left sidebar.
+#. Click on :guilabel:`General` in the left sidebar.
 
-#. Scroll down to the ``Workflow permissions`` section.
+#. Scroll down to the :guilabel:`Workflow permissions` section.
 
-#. Select ``Read and write permissions``.
+#. Select :guilabel:`Read and write permissions`.
 
 #. Done!
 

--- a/news/doc-check-links.rst
+++ b/news/doc-check-links.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Start implementing guilabel in Sphinx for clickable items in tutorials.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/doc/source/getting-started.rst
+++ b/{{ cookiecutter.github_repo_name }}/doc/source/getting-started.rst
@@ -71,3 +71,6 @@ Here is how you attach an image to the documentation. The ``/doc/source/img/scik
     :alt: codecov-in-pr-comment
     :width: 400px
     :align: center
+
+
+Here is how you can do menu selection  :menuselection:`Admin --> Settings` and changing :guilabel:`Privacy level`.


### PR DESCRIPTION
Closes https://github.com/Billingegroup/scikit-package/issues/402

Also I've adopted some "nice looking" buttons using `:ref:guilabel` for button items that would separate from `variable names` as shown below:

<img width="617" alt="Screenshot 2025-05-05 at 10 27 51 PM" src="https://github.com/user-attachments/assets/df97af34-78c9-40e8-b8ee-34246a0c1dd5" />
