### PR TITLE
style: add PR template to save maintainer's time and guide contributors to make docs

### DIFF
--- a/.github/ pull_request_template.md
+++ b/.github/ pull_request_template.md
@@ -1,10 +1,12 @@
 ### What problem does this PR address?
+
 <!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
 
 ### What should the reviewer(s) do?
+
 <!-- Merge the code, provide feedback, initiate a discussion, etc. -->
 
-<!-- 
+<!--
 Use the following checklist items when applicable (select only what applies):
 - [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
     - [ ] Documentation (e.g., tutorials, examples, README) has been updated.

--- a/.github/ pull_request_template.md
+++ b/.github/ pull_request_template.md
@@ -1,0 +1,13 @@
+### What problem does this PR address?
+<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
+
+### What should the reviewer(s) do?
+<!-- Merge the code, provide feedback, initiate a discussion, etc. -->
+
+<!-- 
+Use the following checklist items when applicable (select only what applies):
+- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
+    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
+    - [ ] A tracking issue or plan to update documentation exists.
+- [ ] This PR affects internal functionality only (no user-facing change).
+-->

--- a/news/pr-template.rst
+++ b/news/pr-template.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add PR template to save maintainer's time and to help contributors generate and update public facing documentations.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/{{ cookiecutter.github_repo_name }}/.github/ pull_request_template.md
+++ b/{{ cookiecutter.github_repo_name }}/.github/ pull_request_template.md
@@ -4,7 +4,7 @@
 ### What should the reviewer(s) do?
 <!-- Merge the code, provide feedback, initiate a discussion, etc. -->
 
-<!-- 
+<!--
 Use the following checklist items when applicable (select only what applies):
 - [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
     - [ ] Documentation (e.g., tutorials, examples, README) has been updated.

--- a/{{ cookiecutter.github_repo_name }}/.github/ pull_request_template.md
+++ b/{{ cookiecutter.github_repo_name }}/.github/ pull_request_template.md
@@ -1,0 +1,13 @@
+### What problem does this PR address?
+<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
+
+### What should the reviewer(s) do?
+<!-- Merge the code, provide feedback, initiate a discussion, etc. -->
+
+<!-- 
+Use the following checklist items when applicable (select only what applies):
+- [ ] This PR introduces a public-facing change (e.g., figures, CLI input/output, API).
+    - [ ] Documentation (e.g., tutorials, examples, README) has been updated.
+    - [ ] A tracking issue or plan to update documentation exists.
+- [ ] This PR affects internal functionality only (no user-facing change).
+-->


### PR DESCRIPTION
### What problem does this PR address?
<!-- Provide a brief overview and link to the issue. Attach outputs, including screenshots (before/after), if helpful for the reviewer. -->
Closes #414 - I proposed the following PR template below:

<img width="602" alt="Screenshot 2025-05-09 at 7 42 25 AM" src="https://github.com/user-attachments/assets/4492d026-892d-41a5-a021-7d72f9592d4b" />

I have also adopted the above format in this current PR.

### What should the reviewer(s) do?
<!-- Merge the code, provide feedback, initiate a discussion, etc. -->
@sbillinge Please review the content.


- [x] This PR affects internal functionality only (no user-facing change).