### PR TITLE
docs: add favicon/logo instruction in the doc, resolve all doc building errors

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -142,7 +142,7 @@ The Billinge Group's ``scikit-package`` has been modified from the NSLS-II scien
    :hidden:
    :caption: PROGRAMMING GUIDES
 
-   billinge-group-standards
+   programming-guides/billinge-group-standards
 
 .. toctree::
    :maxdepth: 2
@@ -156,7 +156,7 @@ The Billinge Group's ``scikit-package`` has been modified from the NSLS-II scien
    :hidden:
    :caption: SUPPORT
 
-   frequently-asked-questions
+   support/frequently-asked-questions
 
 .. toctree::
    :maxdepth: 2

--- a/doc/source/programming-guides/billinge-group-standards.rst
+++ b/doc/source/programming-guides/billinge-group-standards.rst
@@ -80,7 +80,7 @@ Pull request practices
 .. _news-item-practice:
 
 
-.. include:: snippets/news-file-format.rst
+.. include:: ../snippets/news-file-format.rst
 
 Unit tests
 ----------

--- a/doc/source/release-guides/conda-forge.rst
+++ b/doc/source/release-guides/conda-forge.rst
@@ -27,7 +27,7 @@ The process is divided into three steps:
 
 :ref:`Step 2. Upload the recipe <conda-forge-recipe-upload>`
 
-    Once you have the ``meta.yaml`` generated, you will create a pull request the staged-recipe repository in the conda-forge repository `here <https://github.com/conda-forge/staged-recipes>`_
+    Once you have the ``meta.yaml`` generated, you will create a pull request to the the `staged-recipes repository <https://github.com/conda-forge/staged-recipes>`_ from your forked repository. The staged-recipes repository is a temporary location for the recipe until it is approved by the conda-forge community.
 
 :ref:`Step 3. Recipe review <conda-forge-recipe-review>`
 

--- a/doc/source/release-guides/pypi-github.rst
+++ b/doc/source/release-guides/pypi-github.rst
@@ -33,7 +33,7 @@ Initiate a release process with GitHub issue
 Start pre-release
 ~~~~~~~~~~~~~~~~~
 
-.. _release-instructions-project-maintainer:
+.. _release-instructions-maintainer:
 
 #. Review the release GitHub issue created in the previous step.
 

--- a/doc/source/snippets/doc-pr-preview.rst
+++ b/doc/source/snippets/doc-pr-preview.rst
@@ -14,14 +14,13 @@
 
 #. Click :guilabel:`Update`.
 
-
-    .. image:: ../img/codecov-configure.png
+    .. image:: ../img/doc-pr-preview-setup.png
       :alt: doc-pr-preview-setup
       :width: 600px
 
 #. Done! Now, in each PR, you will see the following workflow triggered. You can click on the workflow to view its rendered documentation online.
 
-    .. image:: ../img/codecov-configure.png
+    .. image:: ../img/doc-pr-preview-setup-ci.png
       :alt: doc-pr-preview-setup-ci
       :width: 600px
 

--- a/doc/source/snippets/doc-pr-preview.rst
+++ b/doc/source/snippets/doc-pr-preview.rst
@@ -15,13 +15,13 @@
 #. Click :guilabel:`Update`.
 
 
-    .. image:: ../img/doc-pr-preview-setup.png
+    .. image:: ../img/codecov-configure.png
       :alt: doc-pr-preview-setup
       :width: 600px
 
 #. Done! Now, in each PR, you will see the following workflow triggered. You can click on the workflow to view its rendered documentation online.
 
-    .. image:: ../img/doc-pr-preview-setup-ci.png
+    .. image:: ../img/codecov-configure.png
       :alt: doc-pr-preview-setup-ci
       :width: 600px
 

--- a/doc/source/snippets/news-file-format.rst
+++ b/doc/source/snippets/news-file-format.rst
@@ -1,5 +1,3 @@
-.. _news-file-guide:
-
 Why do I need a news file for each PR?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/snippets/scikit-installation.rst
+++ b/doc/source/snippets/scikit-installation.rst
@@ -1,5 +1,3 @@
-.. _scikit-package-installation:
-
 Install ``scikit-package`` with conda
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -1,5 +1,3 @@
-:tocdepth: -1
-
 .. index:: frequently-asked-questions
 
 .. _frequently-asked-questions:
@@ -74,7 +72,7 @@ To solve this problem, run ``git add <file>`` on the files modified by ``pre-com
 How do I ignore words/lines/files in automatic spelling checks in pre-commit?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. include:: snippets/codespell-ignore.rst
+.. include:: ../snippets/codespell-ignore.rst
 
 Project setup
 -------------
@@ -144,7 +142,7 @@ Release
 How can I change who is authorized to release a package?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-In ``.github/workflows/build-wheel-release-upload.yml``, modify ``github_admin_username`` to the desired GitHub username. This username will be able to authorize the release by pushing the tag as instructed :ref:`here <release-instructions-project-maintainer>`.
+In ``.github/workflows/build-wheel-release-upload.yml``, modify ``github_admin_username`` to the desired GitHub username. This username will be able to authorize the release by pushing the tag as instructed in :ref:`release-pypi-github`.
 
 How is the package version set and retrieved?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -185,14 +183,13 @@ We decided to include test files in the PyPI source distribution to facilitate u
 
 The conda-forge CI uses the source code distributed via PyPI to build a Conda package. After building the package, we want to run pytest to ensure all unit tests pass before release. Therefore, test files must be included in the source code. In contrast, no documentation is distributed with the package, as it is already accessible from the GitHub repository and does not serve a practical purpose in the distribution package itself.
 
-
 Documentation
 -------------
 
 How can I preview the documentation in real-time?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. include:: snippets/doc-local-build.rst
+.. include:: ../snippets/doc-local-build.rst
 
 .. _faq-doc-api-standard:
 
@@ -342,7 +339,7 @@ If you are using a namespace import, ``sphinx-apidoc`` will not work. We have de
 How can I preview the documentation in each pull request?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. include:: snippets/doc-pr-preview.rst
+.. include:: ../snippets/doc-pr-preview.rst
 
 How do I re-deploy online documentation without another release?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -351,18 +348,37 @@ Visit the following URL of your package: ``https://github.com/<org-name>/<packag
 
 Click ``Run workflow`` and select the ``main`` branch. Your online documentation will be updated with the latest changes without a new release.
 
+.. _faq-doc-favicon-logo:
+
+How do I add a favicon and logo to the documentation?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In ``doc/source/conf.py``, add the following lines:
+
+.. code-block:: python
+
+  html_theme_options = {
+    "navigation_with_keys": True,
+    "logo_only": True,
+  }
+
+  html_favicon = "<path-to-favicon>"
+  html_logo = "<path-to-logo>"
+
+The clickable logo will be displayed above the menu bar on the left side of the page.
+
 conda-forge
 -----------
 
 How do I add a new admin to the conda-forge feedstock?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Please refer to the admin section in the conda-forge release guide :ref:`here <conda-forge-add-admin>`.
+Please refer to the :ref:`Add a new admin <conda-forge-add-admin>` section.
 
 How do I do pre-release for conda-forge?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Please read our pre-release section in the conda-forge release guide :ref:`here <conda-forge-pre-release>`.
+Please refer to the :ref:`How do I do pre-release? <conda-forge-pre-release>` section.
 
 GitHub Actions
 --------------
@@ -422,7 +438,7 @@ In Level 5, what are the workflows running in each pull request?
 
 #. The third workflow uses the ``Codecov`` app, which adds a comment to the PR summarizing the changes in code coverage as part of the ``.github/workflows/tests-on-pr.yml`` workflow. This workflow fails if no tests are provided for the new code or if the test coverage percentage decreases below the acceptable threshold. The threshold can be adjusted in the ``.codecov.yml`` file located in the project root directory.
 
-#. The fourth workflow checks for a news file in the PR using ``.github/workflows/check-news-item.yml``. If no news item is included for the proposed changes, this workflow fails and leaves a comment prompting the contributor to submit a new PR with the appropriate news file. Please refer to the best practices section on news items :ref:`here <news-item-practice>`.
+#. The fourth workflow checks for a news file in the PR using ``.github/workflows/check-news-item.yml``. If no news item is included for the proposed changes, this workflow fails and leaves a comment prompting the contributor to submit a new PR with the appropriate news file. Please refer to the best practices section on :ref:`news items <news-item-practice>`.
 
 In Level 5, I see that another workflow is running once a PR is merged to ``main``. What is it?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -459,7 +475,7 @@ Dependency management
 .. _faq-dependency-files:
 
 What are ``docs.txt``, ``test.txt``, ``build.txt``, and ``conda.txt`` files under ``\requirements`` in Level 4 and Level 5?
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 :pip.txt: list all PyPI packages required to install the package via `pip install <package-name>`.
 

--- a/doc/source/tutorials/level-5-tutorial.rst
+++ b/doc/source/tutorials/level-5-tutorial.rst
@@ -139,7 +139,7 @@ Build documentation locally
 
 ``/doc`` is the the Sphinx documentation folder. The documentation will be built locally first and then automatically built and hosted on GitHub Pages when a new release is created.
 
-.. include:: snippets/doc-local-build.rst
+.. include:: ../snippets/doc-local-build.rst
 
 Upload your code to GitHub
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -278,7 +278,7 @@ Congratulations! You are done with migrating your package from Level 4 to Level 
 (Optional) Preview documentation in each pull request
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. include:: ../snippets/doc-pr-preview.rst
+Please refer to :ref:`faq-doc-pr-preview`
 
 (Optional) Build API reference documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/news/favicon-faq.rst
+++ b/news/favicon-faq.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add instructions on how to set logo and favicon in the documentation.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
### What problem does this PR address?
Closes https://github.com/Billingegroup/scikit-package/issues/424

- Teaching how to set logo/favicon.
- Fixed doc building errors as shown below:

<img width="399" alt="Screenshot 2025-05-10 at 11 50 06 AM" src="https://github.com/user-attachments/assets/af732fb3-e1e2-4625-8b9b-9e54ad6a0d8c" />

### What should the reviewer(s) do?

Please see my in-line comments for reasons and review.

- [x] This PR affects internal functionality only (no user-facing change).

