### PR TITLE
docs: encourage using .rst backquotes instead of .md style

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,34 +17,34 @@ Release notes
 
 **Added:**
 
-* Add full description of `scikit-package` in `pyproject.toml`.
-* Add motivating statements under the Statement of need section in `index.rst`.
-* Add `package create` and `package update` commands once `scikit-package` is installed.
-* instructions on pre-commit GitHub setup, how to test package and render doc locally
-* FAQ descriptions on Github workflow, namespace package setup, deploy docs via GitHub Actions
+* Add full description of ``scikit-package`` in ``pyproject.toml``.
+* Add motivating statements under the Statement of need section in ``index.rst``.
+* Add ``package create`` and ``package update`` commands once ``scikit-package`` is installed.
+* Add instructions on pre-commit GitHub setup, how to test package and render doc locally
+* Add FAQ descriptions on Github workflow, namespace package setup, deploy docs via GitHub Actions
 * Add extra metadata of email, name, username, license holder, etc. collected to dynamically populate rendered cookiecuttered files.
 * Add conda-forge feedstock creation and maintenance guide.
 * Add instructions for Codecov setup in documentation.
 * Add FAQ section to the documentation on how to customize the template and design decisions for the current setup.
-* Add demo .gif file used in README.rst in generating a package and building documentation with `scikit-package`.
-* Add `Getting started`` page in documentation.
-* Add FAQ section on why both `pip.txt`` and `conda.txt`` added.
+* Add demo .gif file used in README.rst in generating a package and building documentation with ``scikit-package``.
+* Add ``Getting started`` page in documentation.
+* Add FAQ section on why both ``pip.txt```` and ``conda.txt`` added.
 * Add FAQ section on how version is set and retrieved dynamically.
-* Support Billinge group's reusesable workflow by adding requirement files and `environment.yml`.
-* Add Sphinx documentation for `scikit-package`.
+* Support Billinge group's reusesable workflow by adding requirement files and ``environment.yml``.
+* Add Sphinx documentation for ``scikit-package``.
 * Add documentation for Python package release with GitHub Actions.
-* field-list feature in Sphinx to better manage the user inputs in How to cookiecut package section
-* Add automatic linting of .md, .yml, .rst files via prettier hook in `pre-commit`.
-* Add automatic docstring linting with PEP 257 compliance with `docformatter` in `pre-commit`.
-* Configure `PYTHON_MAX_VERSION` and `PYTHON_MIN_VERSION` in `doc/source/conf.py` to increase maintainability throughout the documentation.
+* Use field-list feature in Sphinx to better manage the user inputs in How to cookiecut package section
+* Add automatic linting of .md, .yml, .rst files via prettier hook in ``pre-commit``.
+* Add automatic docstring linting with PEP 257 compliance with ``docformatter`` in ``pre-commit``.
+* Configure ``PYTHON_MAX_VERSION`` and ``PYTHON_MIN_VERSION`` in ``doc/source/conf.py`` to increase maintainability throughout the documentation.
 
 **Changed:**
 
-* Rename repositroy and package name to `scikit-package`.
-* Import `package_dir_name`` in the `__init__.py` instead of `conda_pypi_package_dist_name` to ensure package import is lowercased.
-* Change default line-length to 79 characters in `black`, `flake`, and `isort` configuration files for PEP8 compatibility.
+* Rename repositroy and package name to ``scikit-package``.
+* Import ``package_dir_name```` in the ``__init__.py`` instead of ``conda_pypi_package_dist_name`` to ensure package import is lowercased.
+* Change default line-length to 79 characters in ``black``, ``flake``, and ``isort`` configuration files for PEP8 compatibility.
 * Change question and default answer format on user prompt on C extension and headless GUI with improved wording.
-* Standarlize the current repository based on `scikit-package` structure.
+* Standarlize the current repository based on ``scikit-package`` structure.
 
 **Fixed:**
 

--- a/doc/source/snippets/news-file-format.rst
+++ b/doc/source/snippets/news-file-format.rst
@@ -14,7 +14,7 @@ How do I write good a news item?
 
 - Do not remove ``news/TEMPLATE.rst``. Make a copy called ``<branch-name>.rst``.
 - Do not modify other section headers in the rst file. Replace ``* <news item>`` only.
-- For consistency, start with a capital letter and a verb. End with a period. Ex) ``Add automatic linting of .md, .yml, .rst files via prettier hook in pre-commit.``
+- Start with a capital letter and a verb. End with a period. i.g., ``Add automatic linting of .md, .yml, .rst files via prettier hook in pre-commit.``
 - For trivial changes, still create ``<branch-name>.rst``, but the news item should start with ``* No news:`` so that the news item is not compiled into the ``CHANGELOG.rst`` file during the release process. Here is an example below:
 
     .. code-block:: text
@@ -22,6 +22,8 @@ How do I write good a news item?
         **Added:**
 
         * No news: <brief reason>
+
+- Use the ``rst`` style of backquotes instead of the markdown style of backquotes. For example, use ````scikit-package```` instead of ```scikit-package```.
 
 Where to place the news item in ``<branch-name>.rst``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/snippets/news-file-format.rst
+++ b/doc/source/snippets/news-file-format.rst
@@ -14,7 +14,7 @@ How do I write good a news item?
 
 - Do not remove ``news/TEMPLATE.rst``. Make a copy called ``<branch-name>.rst``.
 - Do not modify other section headers in the rst file. Replace ``* <news item>`` only.
-- Start with a capital letter and a verb. End with a period. i.g., ``Add automatic linting of .md, .yml, .rst files via prettier hook in pre-commit.``
+- Start with a capital letter and a verb. End with a period, e.g., ``Add automatic linting of .md, .yml, .rst files via a prettier hook in pre-commit.``
 - For trivial changes, still create ``<branch-name>.rst``, but the news item should start with ``* No news:`` so that the news item is not compiled into the ``CHANGELOG.rst`` file during the release process. Here is an example below:
 
     .. code-block:: text

--- a/news/news-backquote.rst
+++ b/news/news-backquote.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add a guide to use ``.rst`` backquotes for writing news items.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
Closes https://github.com/Billingegroup/scikit-package/issues/423

### What problem does this PR address?

Adopt `.rst` style backquotes for news items since we are using `.rst` files.

### What should the reviewer(s) do?

Please see the new quick instruction.