### PR TITLE
feat: provide user config file to cookiecuter.

### DIFF
--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,7 +1,9 @@
+import os
 import subprocess
 from argparse import ArgumentParser
 
 SKPKG_GITHUB_URL = "https://github.com/Billingegroup/scikit-package"
+USER_CONFIG_FILE = "~/.skpkgrc"
 
 
 def create(package_type):
@@ -23,15 +25,39 @@ def update():
 
 def run_cookiecutter(repo_url):
     try:
-        subprocess.run(
-            [
-                "cookiecutter",
-                repo_url,
-            ],
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to run scikit-package for the following reason: {e}")
+        config_file = os.environ["SKPKG_CONFIG_FILE"]
+    except KeyError:
+        config_file = USER_CONFIG_FILE
+    config_file = os.path.expandvars(config_file)
+    config_file = os.path.expanduser(config_file)
+    if os.path.exists(path):
+        try:
+            subprocess.run(
+                [
+                    "cookiecutter",
+                    repo_url,
+                    "--config-file",
+                    config_file,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Failed to run scikit-package for the following reason: {e}"
+            )
+    else:
+        try:
+            subprocess.run(
+                [
+                    "cookiecutter",
+                    repo_url,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Failed to run scikit-package for the following reason: {e}"
+            )
 
 
 def setup_subparsers(parser):


### PR DESCRIPTION
`config_file` in the `cookiecutter` is handled in the following way.

```python
# main.py:79
config_dict = get_user_config(
    config_file=config_file,
    default_config=default_config,
)

# main.py: 127
# reply is None as default so this block is excuted
context = generate_context(
    context_file=context_file,
    default_context=config_dict['default_context'],
    extra_context=extra_context,
)
context_for_prompting = context
```

In this PR, user need to provide a file `~/.skpkgrc` or re-define it use environment variable `USER-CONFIG-FILE` like this can overwrite entries in the templates i.e. system, workspace. If the file is not found, this step will be just be skipped.

```python
{
  "default_context": {
      "project_name": "my-default-package-name",
    }
}

```