### PR TITLE
feat: provide user config file to cookiecuter.

### DIFF
--- a/news/user-config.rst
+++ b/news/user-config.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Allow user to set config file to overwrite entires defined in the templates.
+* Allow user to set config file to overwrite entries defined in the templates.
 
 **Changed:**
 

--- a/news/user-config.rst
+++ b/news/user-config.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* let user to use default config file to overwrites options from repo templates.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/user-config.rst
+++ b/news/user-config.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* let user to use default config file to overwrites options from repo templates.
+* Allow user to set config file to overwrite entires defined in the templates.
 
 **Changed:**
 

--- a/src/scikit_package/app.py
+++ b/src/scikit_package/app.py
@@ -1,7 +1,9 @@
+import os
 import subprocess
 from argparse import ArgumentParser
 
 SKPKG_GITHUB_URL = "https://github.com/Billingegroup/scikit-package"
+USER_CONFIG_FILE = "~/.skpkgrc"
 
 
 def create(package_type):
@@ -23,15 +25,39 @@ def update():
 
 def run_cookiecutter(repo_url):
     try:
-        subprocess.run(
-            [
-                "cookiecutter",
-                repo_url,
-            ],
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Failed to run scikit-package for the following reason: {e}")
+        config_file = os.environ["SKPKG_CONFIG_FILE"]
+    except KeyError:
+        config_file = USER_CONFIG_FILE
+    config_file = os.path.expandvars(config_file)
+    config_file = os.path.expanduser(config_file)
+    if os.path.exists(config_file):
+        try:
+            subprocess.run(
+                [
+                    "cookiecutter",
+                    repo_url,
+                    "--config-file",
+                    config_file,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Failed to run scikit-package for the following reason: {e}"
+            )
+    else:
+        try:
+            subprocess.run(
+                [
+                    "cookiecutter",
+                    repo_url,
+                ],
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            print(
+                f"Failed to run scikit-package for the following reason: {e}"
+            )
 
 
 def setup_subparsers(parser):


### PR DESCRIPTION
Closes #375 

Feature:
There will be no difference for the users who don't know this functions. For users who want to save some time correcting the entries defined in the templates i.e user_name, email, organization, they can create a file `~/.skpkgrc` and redefine those entries and the defaults from the templates will be overwritten.

Implementation:

We provide `config_file` input for `cookiecutter` if the file is found.

In the `cookiecutter` this input is handled in the following way.

```python
# main.py:79
config_dict = get_user_config(
    config_file=config_file,
    default_config=default_config,
)

# main.py: 127
# reply is None as default so this block is excuted
context = generate_context(
    context_file=context_file,
    default_context=config_dict['default_context'],
    extra_context=extra_context,
)
context_for_prompting = context
```

In this implementation, user need to provide a file `~/.skpkgrc` or re-define it with environment variable `USER-CONFIG-FILE` to overwrite entries in the templates i.e. system, workspace. If the file is not found, this step will be just be skipped.

```
{
  "default_context": {
      "project_name": "my-default-package-name",
    }
}

```