### PR TITLE
docs: add how to solve GitHub permission CI error encountered with news GitHub CI under FAQ

### DIFF
--- a/doc/source/snippets/github-ci-permission.rst
+++ b/doc/source/snippets/github-ci-permission.rst
@@ -1,0 +1,11 @@
+#. Visit the :guilabel:`Settings` page of the GitHub repository.
+
+#. Click on :guilabel:`Actions` in the left sidebar.
+
+#. Click on :guilabel:`General` in the left sidebar.
+
+#. Scroll down to the :guilabel:`Workflow permissions` section.
+
+#. Select :guilabel:`Read and write permissions`.
+
+#. Done!

--- a/doc/source/support/frequently-asked-questions.rst
+++ b/doc/source/support/frequently-asked-questions.rst
@@ -447,6 +447,12 @@ The workflow ``.github/workflows/matrix-and-codecov-on-merge-to-main.yml`` is tr
 
 .. note:: These workflow files call scripts located at https://github.com/Billingegroup/release-scripts, which are centrally managed by the ``scikit-package`` development team. This centralized approach ensures that individual packages do not need to be updated separately when adding support for new Python versions or operating systems.
 
+I am encountering a 'build' is requesting 'pull-requests: write' error. How do I fix it?
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. include:: ../snippets/github-ci-permission.rst
+
+It is an essential step to set up the news CI. For more, please read :ref:`github-news-ci-permission` section in the Level 5 tutorial.
 
 What is the difference between ``pull_request`` and ``pull_request_target``?
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/source/tutorials/level-5-tutorial.rst
+++ b/doc/source/tutorials/level-5-tutorial.rst
@@ -179,22 +179,14 @@ Setup Codecov token for GitHub repository
 
 .. include:: ../snippets/github-codecov-setup.rst
 
+.. _github-news-ci-permission:
+
 Allow GitHub Actions to write comments in PRs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 As you will see in the next section, we'd like to have GitHub Actions write comments such as warnings. Let's specify the permissions in the GitHub repository settings by following the steps below.
 
-#. Visit the :guilabel:`Settings` page of the GitHub repository.
-
-#. Click on :guilabel:`Actions` in the left sidebar.
-
-#. Click on :guilabel:`General` in the left sidebar.
-
-#. Scroll down to the :guilabel:`Workflow permissions` section.
-
-#. Select :guilabel:`Read and write permissions`.
-
-#. Done!
+.. include:: ../snippets/github-ci-permission.rst
 
 .. _news-keyboard-shortcut:
 

--- a/news/allow-workflow-to-run.rst
+++ b/news/allow-workflow-to-run.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Add how to solve CI error encountered with news GitHub CI under FAQ.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
A while ago @sbillinge mentioned the CI problem while standardizing `bglk-euxfel` in https://github.com/Billingegroup/scikit-package/issues/292 and @bobleesj fixed the problem in the PR attached  in https://github.com/Billingegroup/scikit-package/pull/342.

It was provide din the tutorial, but also providing error msg and solution in the FAQ section as well.